### PR TITLE
Add .bazelci/presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,12 @@
+---
+tasks:
+  ubuntu1804:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  macos:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."


### PR DESCRIPTION
Bazel team has build infrastructure support for bazel rules.

More information in here, https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md

We can create a [bazel CI issue](https://github.com/bazelbuild/continuous-integration/issues/new?template=adding-your-project-to-bazel-ci.md&title=Request+to+add+new+project+%5BPROJECT_NAME%5D&labels=new-project) later to include the actual pipeline.