### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ you must do the following steps:
    # You can provide any version of the CLI that has been uploaded to Maven
    openapi_tools_generator_bazel_repositories(
        openapi_generator_cli_version = "5.1.0",
+       sha256 = "62f9842f0fcd91e4afeafc33f19a7af41f2927c7472c601310cedfc72ff1bb19"
    )
    ```
 


### PR DESCRIPTION
Added sha256 of openapi-generator-cli-5.1.0.jar.
Since a version and sha256 are hardcoded at https://github.com/OpenAPITools/openapi-generator-bazel/blob/master/internal/openapi_generator.bzl#L5, sha256 should be also specified along with openapi_generator_cli_version.