### PR TITLE
Support OpenAPI specs with .yml file ending

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -150,6 +150,7 @@ _openapi_generator = rule(
             allow_single_file = [
                 ".json",
                 ".yaml",
+                ".yml",
             ],
         ),
         "generator": attr.string(mandatory = True),


### PR DESCRIPTION
Currently, only OpenAPI specifications with `.yaml` or `.json` are supported.
YAML files with `.yml` extension are used almost as frequently as `.yaml`, and should probably be supported too.


