### PR TITLE
enabled multiple input files.

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -143,7 +143,7 @@ def _collect_jars(targets):
 _openapi_generator = rule(
     attrs = {
         # downstream dependencies
-        "deps": attr.label_list(),
+        "deps": attr.label_list(allow_files = True),
         # openapi spec file
         "spec": attr.label(
             mandatory = True,


### PR DESCRIPTION
Since `deps` attribute is not allowed to include any files, this tool can only handle a single openapi file.
With this change, user can specify `deps` attribute and generate code from multiple files.