### PR TITLE
add reserved-words-mappings parameter

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -164,7 +164,7 @@ _openapi_generator = rule(
         "system_properties": attr.string_dict(),
         "engine": attr.string(),
         "type_mappings": attr.string_dict(),
-        "reserved_words_mappings": attr.string_dict(),
+        "reserved_words_mappings": attr.string_list(),
         "is_windows": attr.bool(mandatory = True),
         "_jdk": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_runtime"),

--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -61,7 +61,7 @@ def _new_generator_command(ctx, declared_dir, rjars):
     )
     
     gen_cmd += ' --reserved-words-mappings "{reserved_words_mappings}"'.format(
-        reserved_words_mappings = _comma_separated_pairs(ctx.attr.reserved_words_mappings),
+        reserved_words_mappings = ",".join(ctx.attr.reserved_words_mappings),
     )
 
     if ctx.attr.api_package:

--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -59,6 +59,10 @@ def _new_generator_command(ctx, declared_dir, rjars):
     gen_cmd += ' --type-mappings "{mappings}"'.format(
         mappings = _comma_separated_pairs(ctx.attr.type_mappings),
     )
+    
+    gen_cmd += ' --reserved-words-mappings "{reserved_words_mappings}"'.format(
+        reserved_words_mappings = _comma_separated_pairs(ctx.attr.reserved_words_mappings),
+    )
 
     if ctx.attr.api_package:
         gen_cmd += " --api-package {package}".format(
@@ -160,6 +164,7 @@ _openapi_generator = rule(
         "system_properties": attr.string_dict(),
         "engine": attr.string(),
         "type_mappings": attr.string_dict(),
+        "reserved_words_mappings": attr.string_dict(),
         "is_windows": attr.bool(mandatory = True),
         "_jdk": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_runtime"),

--- a/internal/test/BUILD.bazel
+++ b/internal/test/BUILD.bazel
@@ -41,3 +41,13 @@ openapi_generator(
         "Integer": "java.math.BigDecimal",
     },
 )
+
+openapi_generator(
+    name = "petstore_java_reserved_words",
+    generator = "java",
+    spec = "petstore.yaml",
+    reserved_words_mappings = [
+        "interface=interface",
+    ],
+)
+


### PR DESCRIPTION
Add the option to pass the `--reserved-words-mappings` flag
to the generator.