### PR TITLE
Add support for custom templates

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -68,6 +68,10 @@ def _new_generator_command(ctx, declared_dir, rjars):
         gen_cmd += " --api-package {package}".format(
             package = ctx.attr.api_package,
         )
+    if ctx.attr.template_dir:
+        gen_cmd += " --template-dir $PWD/{template}".format(
+            template = ctx.files.template_dir[0].path,
+        )
     if ctx.attr.invoker_package:
         gen_cmd += " --invoker-package {package}".format(
             package = ctx.attr.invoker_package,
@@ -95,7 +99,7 @@ def _impl(ctx):
     inputs = [
         ctx.file.openapi_generator_cli,
         ctx.file.spec,
-    ] + cjars.to_list() + rjars.to_list()
+    ] + cjars.to_list() + rjars.to_list() + ctx.files.template_dir
 
     # TODO: Convert to run
     ctx.actions.run_shell(
@@ -164,6 +168,7 @@ _openapi_generator = rule(
         "additional_properties": attr.string_dict(),
         "system_properties": attr.string_dict(),
         "engine": attr.string(),
+        "template_dir": attr.label(allow_files = True),
         "type_mappings": attr.string_dict(),
         "reserved_words_mappings": attr.string_list(),
         "is_windows": attr.bool(mandatory = True),

--- a/internal/test/BUILD.bazel
+++ b/internal/test/BUILD.bazel
@@ -43,6 +43,21 @@ openapi_generator(
 )
 
 openapi_generator(
+    name = "petstore_java_vertx",
+    generator = "java-vertx-web",
+    spec = "petstore.yaml",
+    template_dir = "templates",
+    additional_properties = {
+        "apiPackage"           : "com.foo.generated.api",
+        "modelPackage"         : "com.foo.generated.model",
+        "dateLibrary"          : "java8",
+        "useBeanValidation"    : "true",
+        "performBeanValidation": "true",
+        "snapshotVersion"      : "true"
+    },
+)
+
+openapi_generator(
     name = "petstore_java_reserved_words",
     generator = "java",
     spec = "petstore.yaml",

--- a/internal/test/templates/api.mustache
+++ b/internal/test/templates/api.mustache
@@ -1,0 +1,20 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import {{invokerPackage}}.ApiResponse;
+
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+
+public interface {{classname}}  {
+{{#operations}}
+  {{#operation}}
+    Single<{{{returnType}}}> {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+  {{/operation}}
+{{/operations}}
+}


### PR DESCRIPTION
It tries to solve this [issue](https://github.com/OpenAPITools/openapi-generator-bazel/issues/23).

I have doubts about how to get the template folder path in the right way. Right now I am picking the first file of the folder and the get its path, but this will fail in the case that the folder is empty. 

https://github.com/OpenAPITools/openapi-generator-bazel/pull/40/files#diff-c1d432311512e669de77c6dfc7da138be54d44e9646442e1d223e9a4a138ab5cR73