### PR TITLE
Parametrize server_urls

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -2,15 +2,19 @@
 
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
-def openapi_tools_generator_bazel_repositories(openapi_generator_cli_version = "5.0.1", sha256 = "e4e45d5441283b2f0f4bf988d02186b85425e7b708b4be0b06e3bfd7c7aa52c7", prefix = "openapi_tools_generator_bazel"):
+def openapi_tools_generator_bazel_repositories(
+        openapi_generator_cli_version = "5.0.1",
+        sha256 = "e4e45d5441283b2f0f4bf988d02186b85425e7b708b4be0b06e3bfd7c7aa52c7",
+        prefix = "openapi_tools_generator_bazel",
+        server_urls = [
+            "https://jcenter.bintray.com/",
+            "https://repo1.maven.org/maven2",
+        ]):
     jvm_maven_import_external(
         name = "openapi_tools_generator_bazel_cli",
         artifact_sha256 = sha256,
         artifact = "org.openapitools:openapi-generator-cli:" + openapi_generator_cli_version,
-        server_urls = [
-            "https://jcenter.bintray.com/",
-            "https://repo1.maven.org/maven2",
-        ],
+        server_urls = server_urls,
     )
     native.bind(
         name = prefix + "/dependency/openapi-generator-cli",


### PR DESCRIPTION
In a company, there could be an internal proxy like nexus, jfrog and so on. So hardcoced `server_urls` seems non-applicable for such configurations.