### PR TITLE
Use current_host_java_runtime jdk

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -185,7 +185,7 @@ _openapi_generator = rule(
         "reserved_words_mappings": attr.string_list(),
         "is_windows": attr.bool(mandatory = True),
         "_jdk": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
             providers = [java_common.JavaRuntimeInfo],
         ),
         "openapi_generator_cli": attr.label(


### PR DESCRIPTION
Otherwise there can be a version mismatch of GLIBC required to run the cli.