### PR TITLE
update `openapi_generator()` to accept multiple spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ you must do the following steps:
 
    load("@openapi_tools_generator_bazel//:defs.bzl", "openapi_tools_generator_bazel_repositories")
 
-   # You can provide any version of the CLI that has been uploaded to Maven
+   # If necessary, you can provide an older or newer version of the CLI if it has been uploaded to Maven
    openapi_tools_generator_bazel_repositories(
        openapi_generator_cli_version = "5.1.0",
        sha256 = "62f9842f0fcd91e4afeafc33f19a7af41f2927c7472c601310cedfc72ff1bb19"
@@ -38,6 +38,6 @@ load("@openapi_tools_generator_bazel//:defs.bzl", "openapi_generator")
 openapi_generator(
     name = "petstore_go",
     generator = "go",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
 )
 ```

--- a/internal/test/BUILD.bazel
+++ b/internal/test/BUILD.bazel
@@ -5,13 +5,13 @@ load("@openapi_tools_generator_bazel//:defs.bzl", "openapi_generator")
 openapi_generator(
     name = "petstore",
     generator = "go",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
 )
 
 openapi_generator(
     name = "petstore_java",
     generator = "java",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
 )
 
 openapi_generator(
@@ -20,13 +20,13 @@ openapi_generator(
         "library": "feign",
     },
     generator = "java",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
 )
 
 openapi_generator(
     name = "petstore_java_no_tests",
     generator = "java",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
     system_properties = {
         "apiTests": "false",
         "modelTests": "false",
@@ -36,7 +36,7 @@ openapi_generator(
 openapi_generator(
     name = "petstore_java_bigdecimal",
     generator = "java",
-    spec = "petstore.yaml",
+    specs = ["petstore.yaml"],
     type_mappings = {
         "Integer": "java.math.BigDecimal",
     },
@@ -45,22 +45,28 @@ openapi_generator(
 openapi_generator(
     name = "petstore_java_reserved_words",
     generator = "java",
-    spec = "petstore.yaml",
     reserved_words_mappings = [
         "interface=interface",
     ],
+    specs = ["petstore.yaml"],
 )
 
 openapi_generator(
     name = "petstore_python_flask_with_config_tag",
+    config = "config.yaml",
     generator = "python-flask",
-    spec = "petstore.yaml",
-    config = "config.yaml"
+    specs = ["petstore.yaml"],
 )
 
 openapi_generator(
     name = "petstore_python_flask_with_template_dir",
     generator = "python-flask",
-    spec = "petstore.yaml",
-    template_dir = "python-templates"
+    specs = ["petstore.yaml"],
+    template_dir = "python-templates",
+)
+
+openapi_generator(
+    name = "petstore_python_nextgen_with_multiple_specs",
+    generator = "python-nextgen",
+    specs = glob(["petstore-separate/**/*.yaml"]),
 )

--- a/internal/test/petstore-separate/common/Error.yaml
+++ b/internal/test/petstore-separate/common/Error.yaml
@@ -1,0 +1,10 @@
+type: object
+required:
+  - code
+  - message
+properties:
+  code:
+    type: integer
+    format: int32
+  message:
+    type: string

--- a/internal/test/petstore-separate/spec/NewPet.yaml
+++ b/internal/test/petstore-separate/spec/NewPet.yaml
@@ -1,0 +1,9 @@
+type: object
+allOf:
+  - $ref: 'Pet.yaml'
+  - required:
+      - name
+    properties:
+      description:
+        type: integer
+        format: int64

--- a/internal/test/petstore-separate/spec/Pet.yaml
+++ b/internal/test/petstore-separate/spec/Pet.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tag:
+    type: string

--- a/internal/test/petstore-separate/spec/parameters.yaml
+++ b/internal/test/petstore-separate/spec/parameters.yaml
@@ -1,0 +1,16 @@
+tagsParam:
+  name: tags
+  in: query
+  description: tags to filter by
+  required: false
+  type: array
+  collectionFormat: csv
+  items:
+    type: string
+limitsParam:
+  name: limit
+  in: query
+  description: maximum number of results to return
+  required: false
+  type: integer
+  format: int32

--- a/internal/test/petstore-separate/spec/swagger.yaml
+++ b/internal/test/petstore-separate/spec/swagger.yaml
@@ -1,0 +1,100 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - $ref: 'parameters.yaml#/tagsParam'
+        - $ref: 'parameters.yaml#/limitsParam'
+      responses:
+        "200":
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: 'Pet.yaml'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '../common/Error.yaml'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: 'NewPet.yaml'
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: 'Pet.yaml'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '../common/Error.yaml'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: 'Pet.yaml'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '../common/Error.yaml'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "204":
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: '../common/Error.yaml'


### PR DESCRIPTION
Alter the openapi generator invocation to generate multiple `-i spec.yaml` parameters on the command line.

Tests pass, and I added a multiple file test for the `petstore-separate` example from [the openapi spec](https://github.com/OAI/OpenAPI-Specification/tree/main/examples/v2.0/yaml/petstore-separate)

This should fix [issue 27](https://github.com/OpenAPITools/openapi-generator-bazel/issues/27)

## Note: it breaks backwards compatibility
I renamed `spec` to `specs` and require a list as input. Callers who do not update will see:
```shell
% bazel query //...            
ERROR: /Users/laz/git/openapi-generator-bazel/internal/test/BUILD.bazel:5:18: //internal/test:petstore: no such attribute 'spec' in '_openapi_generator' rule (did you mean 'specs'?)
ERROR: /Users/laz/git/openapi-generator-bazel/internal/test/BUILD.bazel:5:18: //internal/test:petstore: missing value for mandatory attribute 'specs' in '_openapi_generator' rule
ERROR: package contains errors: internal/test
ERROR: package contains errors: internal/test: //internal/test:petstore: no such attribute 'spec' in '_openapi_generator' rule (did you mean 'specs'?)
ERROR: Error evaluating '//...': error loading package 'internal/test': Package 'internal/test' contains errors
```