### PR TITLE
Add _jdk label as toolchain so execution platform is handled correctly

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -124,6 +124,7 @@ def _impl(ctx):
         ),
         outputs = [declared_dir],
         tools = ctx.files._jdk,
+        toolchain = ctx.attr._jdk.label,
     )
 
     srcs = declared_dir.path


### PR DESCRIPTION
Fixes #58 

According to the documentation for [run_shell](https://bazel.build/rules/lib/builtins/actions#run_shell) the toolchain for the tools should be included for execution platform to be correct:

```
If executable and tools are coming from a toolchain, toolchain type must be set so that the action executes on the correct execution platform.
```

It seems to be working as expected when I have tested this